### PR TITLE
Bump version.undertow in /undertow-jdbc

### DIFF
--- a/undertow-jdbc/pom.xml
+++ b/undertow-jdbc/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <version.undertow>1.3.25.Final-redhat-1</version.undertow>
+        <version.undertow>2.0.28.Final</version.undertow>
         <version.jboss.logmanager>2.0.3.Final-redhat-1</version.jboss.logmanager>
     </properties>
 


### PR DESCRIPTION
Bumps `version.undertow` from 1.3.25.Final-redhat-1 to 2.0.28.Final.

Updates `undertow-core` from 1.3.25.Final-redhat-1 to 2.0.28.Final
- [Release notes](https://github.com/undertow-io/undertow/releases)
- [Commits](https://github.com/undertow-io/undertow/commits/2.0.28.Final)

Updates `undertow-servlet` from 1.3.25.Final-redhat-1 to 2.0.28.Final
- [Release notes](https://github.com/undertow-io/undertow/releases)
- [Commits](https://github.com/undertow-io/undertow/commits/2.0.28.Final)

Signed-off-by: dependabot[bot] <support@github.com>